### PR TITLE
Avoids issue where import evaluates the expression without retrieving the data source

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.3
+current_version = 2.0.4
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -37,5 +37,5 @@ data "aws_caller_identity" "owner" {
 }
 
 locals {
-  create_ram_resource_share_accepter = var.create_ram_principal_association ? data.aws_caller_identity.this[0].account_id != data.aws_caller_identity.owner[0].account_id : false
+  create_ram_resource_share_accepter = var.create_ram_principal_association ? join("", data.aws_caller_identity.this.*.account_id) != join("", data.aws_caller_identity.owner.*.account_id) : false
 }


### PR DESCRIPTION
The problem manifests like so:

```
Error: Invalid index

  on .terraform/modules/ram_share/main.tf line 40, in locals:
  40:   create_ram_resource_share_accepter = var.create_ram_principal_association ? data.aws_caller_identity.this[0].account_id != data.aws_caller_identity.owner[0].account_id : false
    |----------------
    | data.aws_caller_identity.this is empty tuple

The given key does not identify an element in this collection value.
```